### PR TITLE
Qualify to reference

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Perl module {{$dist->name}}
 
 {{$NEXT}}
     * Only decode readdir entries if utf8::all is in effect [leont]
+    * Support direct dirhandles in readdir [leont]
 
 0.010     2013-02-02
     * Don't depend on localizable error strings

--- a/lib/utf8/all.pm
+++ b/lib/utf8/all.pm
@@ -41,6 +41,7 @@ reason to:
 
 use Import::Into;
 use parent qw(Encode charnames utf8 open warnings feature);
+use Symbol qw/qualify_to_ref/;
 
 sub import {
     my $target = caller;
@@ -71,8 +72,9 @@ sub _encode_argv {
 }
 
 sub _utf8_readdir(*) { ## no critic (Subroutines::ProhibitSubroutinePrototypes)
-    my $handle = shift;
-    my $hints = (caller 0)[10];
+    my $pre_handle = shift;
+    my $handle = ref($pre_handle) ? $pre_handle : qualify_to_ref($pre_handle, caller);
+    my ($package, $hints) = (caller 0)[0, 10];
     if (wantarray) {
         my @all_files  = CORE::readdir($handle);
         return @all_files if not $hints->{'utf8::all'};

--- a/t/readdir.t
+++ b/t/readdir.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More 0.96 tests => 2;
+use Test::More 0.96 tests => 3;
 use Encode qw/decode FB_CROAK/;
 
 subtest utf8 => sub {
@@ -37,4 +37,23 @@ subtest context => sub {
 
     is $utf8 => decode('UTF-8', $core, FB_CROAK) or diag "$utf8 : $core";
     closedir $dh;
+};
+
+subtest package_var => sub {
+    plan tests => 3;
+    opendir DH, 'corpus'
+        or die "Couldn't open directory 'corpus'";
+
+    my @files = sort grep { $_ ne '.' and $_ ne '..' } eval { readdir DH; };
+    my @utf8_files;
+    {
+        rewinddir DH;
+        use utf8::all;
+        @utf8_files = sort grep { $_ ne '.' and $_ ne '..' } readdir DH;
+    }
+    closedir DH;
+
+    is_deeply \@utf8_files, [sort "\x{307f}\x{304b}\x{3061}\x{3083}\x{3093}", "testfile"];
+    is $files[0] => $utf8_files[0];
+    is decode('UTF-8', $files[1], FB_CROAK) => $utf8_files[1];
 };


### PR DESCRIPTION
Despite having a \* prototype, readdir currently doesn't support "old-style" filehandle (e.g. `readdir DH`), resulting in a "Bad symbol for dirhandle" exception. This branch fixes that.

It also fixes readdir not being properly lexical, a bug I ran into when writing tests for the other bug.
