### PR TITLE
Add a config for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+branches:
+  except:
+    - /travis/
+skip_tags: true
+
+cache:
+  - C:\strawberry
+
+install:
+  - if not exist "C:\strawberry" cinst strawberryperl
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd C:\projects\%APPVEYOR_PROJECT_NAME%
+  - cpanm --installdeps .
+
+build_script:
+  - perl Build.PL
+  - ./Build
+
+test_script:
+  - ./Build test
+


### PR DESCRIPTION
http://www.appveyor.com/ is continuous integration testing for Windows. utf8::all would do well to use it.

It's not nearly as simple as Travis. This adds a config file for AppVeyor to test against Strawberry Perl. You'll need to sign up and turn it on.