### PR TITLE
Choose a utf-8 encoding that will not break threads.

### DIFF
--- a/t/lexical-again.t
+++ b/t/lexical-again.t
@@ -2,7 +2,7 @@
 # no utf8::all should disable its effects lexically
 # Note: Changes to @ARGV, STDIN, STDOU, and STDERR are always global!
 
-use Test::More tests => 17;
+use Test::More;
 use PerlIO;
 
 my $expected_unicode = "\x{30c6}\x{30b9}\x{30c8}"; # Unicode characters
@@ -52,7 +52,6 @@ for my $fh (keys %handles) {
     my @layers = PerlIO::get_layers($handles{$fh});
     ok(grep(m/utf8/, @layers), "$fh: utf8 does appear in the perlio layers")
         or diag explain { $fh => \@layers };
-    ok(grep(m/utf-8-strict/, @layers), "$fh: utf-8-strict does appear in the perlio layers")
-        or diag explain { $fh => \@layers };
 }
 
+done_testing;

--- a/t/open.t
+++ b/t/open.t
@@ -2,14 +2,14 @@
 # Test opening an actual file
 use utf8::all;
 use PerlIO;
-use Test::More tests => 4;
+use Test::More;
 
 ok open my $in, '<', 'corpus/testfile';
 my @layers = PerlIO::get_layers($in);
 ok(grep(m/utf8/, @layers), 'utf8 appears in the perlio layers')
     or diag explain { $fh => \@layers };
-ok(grep(m/utf-8-strict/, @layers), 'utf-8-strict appears in the perlio layers')
-    or diag explain { $fh => \@layers };
 
 my $contents = do { local $/; <$in>};
 is $contents, "\x{30c6}\x{30b9}\x{30c8}\n", 'unicode retrieved OK';
+
+done_testing;

--- a/t/threads.t
+++ b/t/threads.t
@@ -1,0 +1,33 @@
+#!perl
+
+# Test that utf8::all is choosing the right encoding to not
+# tickle thread bugs.
+
+use strict;
+use warnings;
+
+# This is loaded before threads. It will not be aware of tests run in
+# a thread.
+use Test::More 0.96;
+use Config;
+
+BEGIN {
+    plan skip_all => "Requires threads"
+      if !$Config{usethreads};
+}
+
+# Deliberately before loading threads so we don't cheat and check
+# if threads are loaded, that would be brittle.
+use utf8::all;
+
+use threads;
+use threads::shared;
+
+note "basic utf8 + threads bug"; {
+    my $ok :shared = 0;
+    my $t = threads->create(sub { $ok = 1; });
+    $t->join();
+    ok $ok, "threads ok with utf8::all";
+}
+
+done_testing;

--- a/t/utf8.t
+++ b/t/utf8.t
@@ -19,8 +19,6 @@ use Test::More;
         my @layers = PerlIO::get_layers($fh);
         ok(grep(m/utf8/, @layers), 'utf8 appears in the perlio layers')
             or diag explain { $fh => \@layers };
-        ok(grep(m/utf-8-strict/, @layers), 'utf-8-strict appears in the perlio layers')
-            or diag explain { $fh => \@layers };
     }
 }
 
@@ -33,7 +31,7 @@ use Test::More;
     END { unlink "perlio_test2" }
 
     my @layers = PerlIO::get_layers($test_fh);
-  SKIP: {
+    SKIP: {
         # If we have the Perl Unicode flag set that adds the UTF-8 layer,
         # we need to skip this test.
         skip 'Perl Unicode flag set that always adds UTF-8 layer to output', 1 if (${^UNICODE} & 16);


### PR DESCRIPTION
...or fork() on Windows (implemented with threads).

I've deliberately avoided tests for which particular utf-8 encoding is
used in what scenario because that behavior is deliberately left
undefined for future-proofing. All utf8::all guarantees is threads
still work.

Fixes #42.