### PR TITLE
Add Support for converting ENV to UTF8. Issue #36

### DIFF
--- a/lib/utf8/all.pm
+++ b/lib/utf8/all.pm
@@ -55,6 +55,12 @@ C<@ARGV> gets converted from UTF-8 octets to Unicode characters (when
 C<utf8::all> is used from the C<main> package). This is similar to the
 behaviour of the C<-CA> perl command-line switch (see L<perlrun>).
 
+
+=item *
+
+C<%ENV> gets tied to a C<Tie::StdHash> based object that decodes UTF-8 
+in Environment Variables to Unicode characters.
+
 =item *
 
 C<readdir>, C<readlink>, C<readpipe> (including the C<qx//> and
@@ -90,10 +96,10 @@ C<STDERR> file handles is always global and can not be undone!
 =head2 Enabling/Disabling Global Features
 
 As described above, the default behaviour of C<utf8::all> is to
-convert C<@ARGV> and to open the C<STDIN>, C<STDOUT>, and C<STDERR>
-file handles with UTF-8 encoding, and override the C<readlink> and
-C<readdir> functions and C<glob> operators when C<utf8::all> is used
-from the C<main> package.
+convert C<@ARGV> and to open the C<STDIN>, C<STDOUT>, and 
+C<STDERR> file handles with UTF-8 encoding, and override the C<readlink> and
+C<readdir> functions and C<glob> operatorsi, and tie C<%ENV> to handle UTF-8 in
+Environment variables when C<utf8::all> is used from the C<main> package.
 
 If you want to disable these features even when C<utf8::all> is used
 from the C<main> package, add the option C<NO-GLOBAL> (or
@@ -340,5 +346,5 @@ sub FETCH {
 	my $self = shift;
 	my $value = $self->SUPER::FETCH(@_);
 	return $value ? $_UTF8->decode($value, $utf8::all::UTF8_CHECK) : $value;
-}	
+}
 1;

--- a/lib/utf8/all.pm
+++ b/lib/utf8/all.pm
@@ -55,6 +55,12 @@ C<@ARGV> gets converted from UTF-8 octets to Unicode characters (when
 C<utf8::all> is used from the C<main> package). This is similar to the
 behaviour of the C<-CA> perl command-line switch (see L<perlrun>).
 
+
+=item *
+
+C<%ENV> gets tied to a C<Tie::StdHash> based object that decodes UTF-8 
+in Environment Variables to Unicode characters.
+
 =item *
 
 C<readdir>, C<readlink>, C<readpipe> (including the C<qx//> and
@@ -90,10 +96,10 @@ C<STDERR> file handles is always global and can not be undone!
 =head2 Enabling/Disabling Global Features
 
 As described above, the default behaviour of C<utf8::all> is to
-convert C<@ARGV> and to open the C<STDIN>, C<STDOUT>, and C<STDERR>
-file handles with UTF-8 encoding, and override the C<readlink> and
-C<readdir> functions and C<glob> operators when C<utf8::all> is used
-from the C<main> package.
+convert C<@ARGV> and to open the C<STDIN>, C<STDOUT>, and 
+C<STDERR> file handles with UTF-8 encoding, and override the C<readlink> and
+C<readdir> functions and C<glob> operatorsi, and tie C<%ENV> to handle UTF-8 in
+Environment variables when C<utf8::all> is used from the C<main> package.
 
 If you want to disable these features even when C<utf8::all> is used
 from the C<main> package, add the option C<NO-GLOBAL> (or
@@ -232,6 +238,13 @@ sub import {
         }
     }
 
+
+	#Parse %ENV and decode any UTF-8 byte strings.
+	unless ($no_global) {
+		tie %ENV, "utf8::all::TieENV", %ENV;
+	}
+
+
     return;
 }
 
@@ -248,6 +261,9 @@ sub unimport { ## no critic (Subroutines::ProhibitBuiltinHomonyms)
     unless ($^O =~ /MSWin32|cygwin|dos|os2/) {
         $^H{'utf8::all'} = 0; # Reset compiler hint
     }
+
+	#Restore %ENV
+	untie %ENV;
 
     return;
 }
@@ -311,4 +327,27 @@ pragma. See L<RT
 
 =cut
 
+
+package utf8::all::TieENV;
+
+use strict;
+use warnings;
+use Tie::Hash;
+use base 'Tie::StdHash';
+
+sub TIEHASH {
+	my $class = shift;
+	my $self = bless {}, $class;
+	while( my ($k, $v) = splice @_, 0, 2 ) {
+		$self->{$k} = $v;
+	}
+
+	return $self;
+}
+
+sub FETCH {
+	my $self = shift;
+	my $value = $self->SUPER::FETCH(@_);
+	return $value ? $_UTF8->decode($value, $utf8::all::UTF8_CHECK) : $value;
+}
 1;

--- a/lib/utf8/all.pm
+++ b/lib/utf8/all.pm
@@ -262,6 +262,9 @@ sub unimport { ## no critic (Subroutines::ProhibitBuiltinHomonyms)
         $^H{'utf8::all'} = 0; # Reset compiler hint
     }
 
+	#Restore %ENV
+	untie %ENV;
+
     return;
 }
 

--- a/lib/utf8/all.pm
+++ b/lib/utf8/all.pm
@@ -58,7 +58,7 @@ behaviour of the C<-CA> perl command-line switch (see L<perlrun>).
 
 =item *
 
-C<%ENV> gets tied to a C<Tie::StdHash> based object that decodes UTF-8 
+C<%ENV> gets tied to a C<Tie::StdHash> based object that decodes UTF-8
 in Environment Variables to Unicode characters.
 
 =item *
@@ -239,10 +239,10 @@ sub import {
     }
 
 
-	#Parse %ENV and decode any UTF-8 byte strings.
-	unless ($no_global) {
-		tie %ENV, "utf8::all::TieENV", %ENV;
-	}
+    #Parse %ENV and decode any UTF-8 byte strings.
+    unless ($no_global) {
+        tie %ENV, "utf8::all::TieENV", %ENV;
+    }
 
 
     return;
@@ -262,8 +262,8 @@ sub unimport { ## no critic (Subroutines::ProhibitBuiltinHomonyms)
         $^H{'utf8::all'} = 0; # Reset compiler hint
     }
 
-	#Restore %ENV
-	untie %ENV;
+    #Restore %ENV
+    untie %ENV;
 
     return;
 }
@@ -336,18 +336,18 @@ use Tie::Hash;
 use base 'Tie::StdHash';
 
 sub TIEHASH {
-	my $class = shift;
-	my $self = bless {}, $class;
-	while( my ($k, $v) = splice @_, 0, 2 ) {
-		$self->{$k} = $v;
-	}
+    my $class = shift;
+    my $self = bless {}, $class;
+    while( my ($k, $v) = splice @_, 0, 2 ) {
+        $self->{$k} = $v;
+    }
 
-	return $self;
+    return $self;
 }
 
 sub FETCH {
-	my $self = shift;
-	my $value = $self->SUPER::FETCH(@_);
-	return $value ? $_UTF8->decode($value, $utf8::all::UTF8_CHECK) : $value;
+    my $self = shift;
+    my $value = $self->SUPER::FETCH(@_);
+    return $value ? $_UTF8->decode($value, $utf8::all::UTF8_CHECK) : $value;
 }
 1;

--- a/t/ENV.t
+++ b/t/ENV.t
@@ -1,0 +1,40 @@
+#!perl
+# Test that utf8::all makes @ENV utf8
+use strict;
+use warnings;
+
+use Encode;
+
+use Test::More tests => 12;
+
+# føø
+local $ENV{FOO} = join '', map {chr $_} ( 0x66, 0xc3, 0xb8, 0xc3, 0xb8 );
+
+# bar
+local $ENV{BAR} = 'bar';
+
+# bāz
+local $ENV{BAZ} = join '', map {chr $_} ( 0x62, 0xc4, 0x81, 0x7a );
+
+# テスト
+local $ENV{BOO} = join '', map {chr $_} (0xe3, 0x83, 0x86, 0xe3, 0x82, 0xb9, 0xe3, 0x83, 0x88);
+
+use utf8::all;
+
+# føø bar bāz テスト but now as unicode characters
+is $ENV{FOO}, "\x{66}\x{f8}\x{f8}", "ENV as unicode characters instead of utf-8 octets";
+is(length($ENV{FOO}), 3, "string is seen as 3 char bytes when seen as utf-8");
+ok(Encode::is_utf8($ENV{FOO}), "String is seen as Perl Internal UTF-8");
+
+is $ENV{BAR}, "\x{62}\x{61}\x{72}", "ENV as unicode characters instead of utf-8 octets";
+is(length($ENV{BAR}), 3, "string is seen as 3 char bytes when seen as utf-8");
+ok(Encode::is_utf8($ENV{BAR}), "String is seen as Perl Internal UTF-8");
+
+is $ENV{BAZ}, "\x{62}\x{101}\x{7a}", "ENV as unicode characters instead of utf-8 octets";
+is(length($ENV{BAZ}), 3, "string is seen as 5 char bytes when seen as utf-8");
+ok(Encode::is_utf8($ENV{BAZ}), "String is seen as Perl Internal UTF-8");
+
+is $ENV{BOO}, "\x{30c6}\x{30b9}\x{30c8}", "ENV as unicode characters instead of utf-8 octets";
+is(length($ENV{BOO}), 3, "string is seen as 9 char bytes when seen as utf-8");
+ok(Encode::is_utf8($ENV{BOO}), "String is seen as Perl Internal UTF-8");
+

--- a/t/ENV.t
+++ b/t/ENV.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Encode;
 
-use Test::More tests => 1;
+use Test::More tests => 12;
 
 # føø
 local $ENV{FOO} = join '', map {chr $_} ( 0x66, 0xc3, 0xb8, 0xc3, 0xb8 );
@@ -19,32 +19,22 @@ local $ENV{BAZ} = join '', map {chr $_} ( 0x62, 0xc4, 0x81, 0x7a );
 # テスト
 local $ENV{BOO} = join '', map {chr $_} (0xe3, 0x83, 0x86, 0xe3, 0x82, 0xb9, 0xe3, 0x83, 0x88);
 
-subtest 'ENV is not converted to Perl UTF8' => sub {
-	use utf8::all;
-	
-	# føø bar bāz テスト but now as unicode characters
-	is $ENV{FOO}, "\x{66}\x{f8}\x{f8}", "ENV as unicode characters instead of utf-8 octets";
-	is(length($ENV{FOO}), 3, "string is seen as 3 char bytes when seen as utf-8");
-	ok(Encode::is_utf8($ENV{FOO}), "String is seen as Perl Internal UTF-8");
+use utf8::all;
 
-	is $ENV{BAR}, "\x{62}\x{61}\x{72}", "ENV as unicode characters instead of utf-8 octets";
-	is(length($ENV{BAR}), 3, "string is seen as 3 char bytes when seen as utf-8");
-	ok(Encode::is_utf8($ENV{BAR}), "String is seen as Perl Internal UTF-8");
+# føø bar bāz テスト but now as unicode characters
+is $ENV{FOO}, "\x{66}\x{f8}\x{f8}", "ENV as unicode characters instead of utf-8 octets";
+is(length($ENV{FOO}), 3, "string is seen as 3 char bytes when seen as utf-8");
+ok(Encode::is_utf8($ENV{FOO}), "String is seen as Perl Internal UTF-8");
 
-	is $ENV{BAZ}, "\x{62}\x{101}\x{7a}", "ENV as unicode characters instead of utf-8 octets";
-	is(length($ENV{BAZ}), 3, "string is seen as 5 char bytes when seen as utf-8");
-	ok(Encode::is_utf8($ENV{BAZ}), "String is seen as Perl Internal UTF-8");
+is $ENV{BAR}, "\x{62}\x{61}\x{72}", "ENV as unicode characters instead of utf-8 octets";
+is(length($ENV{BAR}), 3, "string is seen as 3 char bytes when seen as utf-8");
+ok(Encode::is_utf8($ENV{BAR}), "String is seen as Perl Internal UTF-8");
 
-	is $ENV{BOO}, "\x{30c6}\x{30b9}\x{30c8}", "ENV as unicode characters instead of utf-8 octets";
-	is(length($ENV{BOO}), 3, "string is seen as 9 char bytes when seen as utf-8");
-	ok(Encode::is_utf8($ENV{BOO}), "String is seen as Perl Internal UTF-8");
+is $ENV{BAZ}, "\x{62}\x{101}\x{7a}", "ENV as unicode characters instead of utf-8 octets";
+is(length($ENV{BAZ}), 3, "string is seen as 5 char bytes when seen as utf-8");
+ok(Encode::is_utf8($ENV{BAZ}), "String is seen as Perl Internal UTF-8");
 
-};
+is $ENV{BOO}, "\x{30c6}\x{30b9}\x{30c8}", "ENV as unicode characters instead of utf-8 octets";
+is(length($ENV{BOO}), 3, "string is seen as 9 char bytes when seen as utf-8");
+ok(Encode::is_utf8($ENV{BOO}), "String is seen as Perl Internal UTF-8");
 
-sub utf8_dump {
-	my ($string) = @_;
-	my $flag = Encode::is_utf8($string) ? 1 : 0;
-	use bytes;
-	my @internal_rep_bytes = unpack('C*', $string);
-	return $flag . '(' . join (' ', map { sprintf("%02x", $_) } @internal_rep_bytes) . ')';
-}

--- a/t/ENV.t
+++ b/t/ENV.t
@@ -1,0 +1,50 @@
+#!perl
+# Test that utf8::all makes @ENV utf8
+use strict;
+use warnings;
+
+use Encode;
+
+use Test::More tests => 1;
+
+# føø
+local $ENV{FOO} = join '', map {chr $_} ( 0x66, 0xc3, 0xb8, 0xc3, 0xb8 );
+
+# bar
+local $ENV{BAR} = 'bar';
+
+# bāz
+local $ENV{BAZ} = join '', map {chr $_} ( 0x62, 0xc4, 0x81, 0x7a );
+
+# テスト
+local $ENV{BOO} = join '', map {chr $_} (0xe3, 0x83, 0x86, 0xe3, 0x82, 0xb9, 0xe3, 0x83, 0x88);
+
+subtest 'ENV is not converted to Perl UTF8' => sub {
+	use utf8::all;
+	
+	# føø bar bāz テスト but now as unicode characters
+	is $ENV{FOO}, "\x{66}\x{f8}\x{f8}", "ENV as unicode characters instead of utf-8 octets";
+	is(length($ENV{FOO}), 3, "string is seen as 3 char bytes when seen as utf-8");
+	ok(Encode::is_utf8($ENV{FOO}), "String is seen as Perl Internal UTF-8");
+
+	is $ENV{BAR}, "\x{62}\x{61}\x{72}", "ENV as unicode characters instead of utf-8 octets";
+	is(length($ENV{BAR}), 3, "string is seen as 3 char bytes when seen as utf-8");
+	ok(Encode::is_utf8($ENV{BAR}), "String is seen as Perl Internal UTF-8");
+
+	is $ENV{BAZ}, "\x{62}\x{101}\x{7a}", "ENV as unicode characters instead of utf-8 octets";
+	is(length($ENV{BAZ}), 3, "string is seen as 5 char bytes when seen as utf-8");
+	ok(Encode::is_utf8($ENV{BAZ}), "String is seen as Perl Internal UTF-8");
+
+	is $ENV{BOO}, "\x{30c6}\x{30b9}\x{30c8}", "ENV as unicode characters instead of utf-8 octets";
+	is(length($ENV{BOO}), 3, "string is seen as 9 char bytes when seen as utf-8");
+	ok(Encode::is_utf8($ENV{BOO}), "String is seen as Perl Internal UTF-8");
+
+};
+
+sub utf8_dump {
+	my ($string) = @_;
+	my $flag = Encode::is_utf8($string) ? 1 : 0;
+	use bytes;
+	my @internal_rep_bytes = unpack('C*', $string);
+	return $flag . '(' . join (' ', map { sprintf("%02x", $_) } @internal_rep_bytes) . ')';
+}

--- a/t/ENV_no_global.t
+++ b/t/ENV_no_global.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Encode;
 
-use Test::More tests =>1;
+use Test::More tests =>12;
 
 # føø
 local $ENV{FOO} = join '', map {chr $_} ( 0x66, 0xc3, 0xb8, 0xc3, 0xb8 );
@@ -18,9 +18,9 @@ local $ENV{BAZ} = join '', map {chr $_} ( 0x62, 0xc4, 0x81, 0x7a );
 
 # テスト
 local $ENV{BOO} = join '', map {chr $_} (0xe3, 0x83, 0x86, 0xe3, 0x82, 0xb9, 0xe3, 0x83, 0x88);
+use utf8::all qw/NO-GLOBAL/;
 
-subtest 'ENV is not converted to Perl UTF8' => sub {
-	use utf8::all qw/NO-GLOBAL/;
+{	
 	
 	is($ENV{FOO}, "\x{66}\x{c3}\x{b8}\x{c3}\x{b8}", "ENV{FOO} $ENV{FOO} is not unicode characters instead of utf-8 octets");
 	is(length($ENV{FOO}), 5, "string is seen as 5 char bytes when not seen as utf-8");
@@ -38,5 +38,5 @@ subtest 'ENV is not converted to Perl UTF8' => sub {
 	is(length($ENV{BOO}), 9, "string is seen as 9 char bytes when not seen as utf-8");
 	ok(!Encode::is_utf8($ENV{BOO}), "String is not seen as Perl Internal UTF-8");
 
-};
+}
 

--- a/t/ENV_no_global.t
+++ b/t/ENV_no_global.t
@@ -1,0 +1,42 @@
+#!perl
+# Test that utf8::all makes @ENV utf8
+use strict;
+use warnings;
+
+use Encode;
+
+use Test::More tests =>12;
+
+# føø
+local $ENV{FOO} = join '', map {chr $_} ( 0x66, 0xc3, 0xb8, 0xc3, 0xb8 );
+
+# bar
+local $ENV{BAR} = 'bar';
+
+# bāz
+local $ENV{BAZ} = join '', map {chr $_} ( 0x62, 0xc4, 0x81, 0x7a );
+
+# テスト
+local $ENV{BOO} = join '', map {chr $_} (0xe3, 0x83, 0x86, 0xe3, 0x82, 0xb9, 0xe3, 0x83, 0x88);
+use utf8::all qw/NO-GLOBAL/;
+
+{	
+	
+	is($ENV{FOO}, "\x{66}\x{c3}\x{b8}\x{c3}\x{b8}", "ENV{FOO} $ENV{FOO} is not unicode characters instead of utf-8 octets");
+	is(length($ENV{FOO}), 5, "string is seen as 5 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{FOO}), "String is not seen as Perl Internal UTF-8");
+
+	is($ENV{BAR}, "\x{62}\x{61}\x{72}", "ENV{BAR} $ENV{BAR} is not unicode characters instead of utf-8 octets");
+	is(length($ENV{BAR}), 3, "string is seen as 3 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{BAR}), "String is not seen as Perl Internal UTF-8");
+
+	is($ENV{BAZ}, "\x{62}\x{c4}\x{81}\x{7a}", "ENV{BAZ} $ENV{BAZ} is not unicode characters instead of utf-9 octets");
+	is(length($ENV{BAZ}), 4, "string is seen as 5 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{BAZ}), "String is not seen as Perl Internal UTF-8");
+
+	is($ENV{BOO}, "\x{e3}\x{83}\x{86}\x{e3}\x{82}\x{b9}\x{e3}\x{83}\x{88}", "ENV{BOO} $ENV{BOO} is not unicode characters instead of utf-8 octets");
+	is(length($ENV{BOO}), 9, "string is seen as 9 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{BOO}), "String is not seen as Perl Internal UTF-8");
+
+}
+

--- a/t/ENV_no_global.t
+++ b/t/ENV_no_global.t
@@ -20,23 +20,23 @@ local $ENV{BAZ} = join '', map {chr $_} ( 0x62, 0xc4, 0x81, 0x7a );
 local $ENV{BOO} = join '', map {chr $_} (0xe3, 0x83, 0x86, 0xe3, 0x82, 0xb9, 0xe3, 0x83, 0x88);
 use utf8::all qw/NO-GLOBAL/;
 
-{	
-	
-	is($ENV{FOO}, "\x{66}\x{c3}\x{b8}\x{c3}\x{b8}", "ENV{FOO} $ENV{FOO} is not unicode characters instead of utf-8 octets");
-	is(length($ENV{FOO}), 5, "string is seen as 5 char bytes when not seen as utf-8");
-	ok(!Encode::is_utf8($ENV{FOO}), "String is not seen as Perl Internal UTF-8");
+{
+    
+    is($ENV{FOO}, "\x{66}\x{c3}\x{b8}\x{c3}\x{b8}", "ENV{FOO} $ENV{FOO} is not unicode characters instead of utf-8 octets");
+    is(length($ENV{FOO}), 5, "string is seen as 5 char bytes when not seen as utf-8");
+    ok(!Encode::is_utf8($ENV{FOO}), "String is not seen as Perl Internal UTF-8");
 
-	is($ENV{BAR}, "\x{62}\x{61}\x{72}", "ENV{BAR} $ENV{BAR} is not unicode characters instead of utf-8 octets");
-	is(length($ENV{BAR}), 3, "string is seen as 3 char bytes when not seen as utf-8");
-	ok(!Encode::is_utf8($ENV{BAR}), "String is not seen as Perl Internal UTF-8");
+    is($ENV{BAR}, "\x{62}\x{61}\x{72}", "ENV{BAR} $ENV{BAR} is not unicode characters instead of utf-8 octets");
+    is(length($ENV{BAR}), 3, "string is seen as 3 char bytes when not seen as utf-8");
+    ok(!Encode::is_utf8($ENV{BAR}), "String is not seen as Perl Internal UTF-8");
 
-	is($ENV{BAZ}, "\x{62}\x{c4}\x{81}\x{7a}", "ENV{BAZ} $ENV{BAZ} is not unicode characters instead of utf-9 octets");
-	is(length($ENV{BAZ}), 4, "string is seen as 5 char bytes when not seen as utf-8");
-	ok(!Encode::is_utf8($ENV{BAZ}), "String is not seen as Perl Internal UTF-8");
+    is($ENV{BAZ}, "\x{62}\x{c4}\x{81}\x{7a}", "ENV{BAZ} $ENV{BAZ} is not unicode characters instead of utf-9 octets");
+    is(length($ENV{BAZ}), 4, "string is seen as 5 char bytes when not seen as utf-8");
+    ok(!Encode::is_utf8($ENV{BAZ}), "String is not seen as Perl Internal UTF-8");
 
-	is($ENV{BOO}, "\x{e3}\x{83}\x{86}\x{e3}\x{82}\x{b9}\x{e3}\x{83}\x{88}", "ENV{BOO} $ENV{BOO} is not unicode characters instead of utf-8 octets");
-	is(length($ENV{BOO}), 9, "string is seen as 9 char bytes when not seen as utf-8");
-	ok(!Encode::is_utf8($ENV{BOO}), "String is not seen as Perl Internal UTF-8");
+    is($ENV{BOO}, "\x{e3}\x{83}\x{86}\x{e3}\x{82}\x{b9}\x{e3}\x{83}\x{88}", "ENV{BOO} $ENV{BOO} is not unicode characters instead of utf-8 octets");
+    is(length($ENV{BOO}), 9, "string is seen as 9 char bytes when not seen as utf-8");
+    ok(!Encode::is_utf8($ENV{BOO}), "String is not seen as Perl Internal UTF-8");
 
 }
 

--- a/t/ENV_no_global.t
+++ b/t/ENV_no_global.t
@@ -1,0 +1,42 @@
+#!perl
+# Test that utf8::all makes @ENV utf8
+use strict;
+use warnings;
+
+use Encode;
+
+use Test::More tests =>1;
+
+# føø
+local $ENV{FOO} = join '', map {chr $_} ( 0x66, 0xc3, 0xb8, 0xc3, 0xb8 );
+
+# bar
+local $ENV{BAR} = 'bar';
+
+# bāz
+local $ENV{BAZ} = join '', map {chr $_} ( 0x62, 0xc4, 0x81, 0x7a );
+
+# テスト
+local $ENV{BOO} = join '', map {chr $_} (0xe3, 0x83, 0x86, 0xe3, 0x82, 0xb9, 0xe3, 0x83, 0x88);
+
+subtest 'ENV is not converted to Perl UTF8' => sub {
+	use utf8::all qw/NO-GLOBAL/;
+	
+	is($ENV{FOO}, "\x{66}\x{c3}\x{b8}\x{c3}\x{b8}", "ENV{FOO} $ENV{FOO} is not unicode characters instead of utf-8 octets");
+	is(length($ENV{FOO}), 5, "string is seen as 5 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{FOO}), "String is not seen as Perl Internal UTF-8");
+
+	is($ENV{BAR}, "\x{62}\x{61}\x{72}", "ENV{BAR} $ENV{BAR} is not unicode characters instead of utf-8 octets");
+	is(length($ENV{BAR}), 3, "string is seen as 3 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{BAR}), "String is not seen as Perl Internal UTF-8");
+
+	is($ENV{BAZ}, "\x{62}\x{c4}\x{81}\x{7a}", "ENV{BAZ} $ENV{BAZ} is not unicode characters instead of utf-9 octets");
+	is(length($ENV{BAZ}), 4, "string is seen as 5 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{BAZ}), "String is not seen as Perl Internal UTF-8");
+
+	is($ENV{BOO}, "\x{e3}\x{83}\x{86}\x{e3}\x{82}\x{b9}\x{e3}\x{83}\x{88}", "ENV{BOO} $ENV{BOO} is not unicode characters instead of utf-8 octets");
+	is(length($ENV{BOO}), 9, "string is seen as 9 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{BOO}), "String is not seen as Perl Internal UTF-8");
+
+};
+

--- a/t/ENV_no_utf8_all.t
+++ b/t/ENV_no_utf8_all.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Encode;
 
-use Test::More tests => 1;
+use Test::More tests => 12;
 
 # føø
 local $ENV{FOO} = join '', map {chr $_} ( 0x66, 0xc3, 0xb8, 0xc3, 0xb8 );
@@ -19,7 +19,10 @@ local $ENV{BAZ} = join '', map {chr $_} ( 0x62, 0xc4, 0x81, 0x7a );
 # テスト
 local $ENV{BOO} = join '', map {chr $_} (0xe3, 0x83, 0x86, 0xe3, 0x82, 0xb9, 0xe3, 0x83, 0x88);
 
-subtest 'ENV is not converted to Perl UTF8' => sub {
+use utf8::all;
+
+{
+	no utf8::all;
 	
 	# føø bar bāz テスト but now as unicode characters
 	is($ENV{FOO}, "\x{66}\x{c3}\x{b8}\x{c3}\x{b8}", "ENV{FOO} $ENV{FOO} is not unicode characters instead of utf-8 octets");
@@ -38,5 +41,5 @@ subtest 'ENV is not converted to Perl UTF8' => sub {
 	is(length($ENV{BOO}), 9, "string is seen as 9 char bytes when not seen as utf-8");
 	ok(!Encode::is_utf8($ENV{BOO}), "String is not seen as Perl Internal UTF-8");
 
-};
+}
 

--- a/t/ENV_no_utf8_all.t
+++ b/t/ENV_no_utf8_all.t
@@ -1,0 +1,45 @@
+#!perl
+# Test that utf8::all makes @ENV utf8
+use strict;
+use warnings;
+
+use Encode;
+
+use Test::More tests => 12;
+
+# føø
+local $ENV{FOO} = join '', map {chr $_} ( 0x66, 0xc3, 0xb8, 0xc3, 0xb8 );
+
+# bar
+local $ENV{BAR} = 'bar';
+
+# bāz
+local $ENV{BAZ} = join '', map {chr $_} ( 0x62, 0xc4, 0x81, 0x7a );
+
+# テスト
+local $ENV{BOO} = join '', map {chr $_} (0xe3, 0x83, 0x86, 0xe3, 0x82, 0xb9, 0xe3, 0x83, 0x88);
+
+use utf8::all;
+
+{
+	no utf8::all;
+	
+	# føø bar bāz テスト but now as unicode characters
+	is($ENV{FOO}, "\x{66}\x{c3}\x{b8}\x{c3}\x{b8}", "ENV{FOO} $ENV{FOO} is not unicode characters instead of utf-8 octets");
+	is(length($ENV{FOO}), 5, "string is seen as 5 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{FOO}), "String is not seen as Perl Internal UTF-8");
+
+	is($ENV{BAR}, "\x{62}\x{61}\x{72}", "ENV{BAR} $ENV{BAR} is not unicode characters instead of utf-8 octets");
+	is(length($ENV{BAR}), 3, "string is seen as 3 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{BAR}), "String is not seen as Perl Internal UTF-8");
+
+	is($ENV{BAZ}, "\x{62}\x{c4}\x{81}\x{7a}", "ENV{BAZ} $ENV{BAZ} is not unicode characters instead of utf-9 octets");
+	is(length($ENV{BAZ}), 4, "string is seen as 5 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{BAZ}), "String is not seen as Perl Internal UTF-8");
+
+	is($ENV{BOO}, "\x{e3}\x{83}\x{86}\x{e3}\x{82}\x{b9}\x{e3}\x{83}\x{88}", "ENV{BOO} $ENV{BOO} is not unicode characters instead of utf-8 octets");
+	is(length($ENV{BOO}), 9, "string is seen as 9 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{BOO}), "String is not seen as Perl Internal UTF-8");
+
+}
+

--- a/t/ENV_no_utf8_all.t
+++ b/t/ENV_no_utf8_all.t
@@ -22,24 +22,24 @@ local $ENV{BOO} = join '', map {chr $_} (0xe3, 0x83, 0x86, 0xe3, 0x82, 0xb9, 0xe
 use utf8::all;
 
 {
-	no utf8::all;
-	
-	# føø bar bāz テスト but now as unicode characters
-	is($ENV{FOO}, "\x{66}\x{c3}\x{b8}\x{c3}\x{b8}", "ENV{FOO} $ENV{FOO} is not unicode characters instead of utf-8 octets");
-	is(length($ENV{FOO}), 5, "string is seen as 5 char bytes when not seen as utf-8");
-	ok(!Encode::is_utf8($ENV{FOO}), "String is not seen as Perl Internal UTF-8");
+    no utf8::all;
 
-	is($ENV{BAR}, "\x{62}\x{61}\x{72}", "ENV{BAR} $ENV{BAR} is not unicode characters instead of utf-8 octets");
-	is(length($ENV{BAR}), 3, "string is seen as 3 char bytes when not seen as utf-8");
-	ok(!Encode::is_utf8($ENV{BAR}), "String is not seen as Perl Internal UTF-8");
+    # føø bar bāz テスト but now as unicode characters
+    is($ENV{FOO}, "\x{66}\x{c3}\x{b8}\x{c3}\x{b8}", "ENV{FOO} $ENV{FOO} is not unicode characters instead of utf-8 octets");
+    is(length($ENV{FOO}), 5, "string is seen as 5 char bytes when not seen as utf-8");
+    ok(!Encode::is_utf8($ENV{FOO}), "String is not seen as Perl Internal UTF-8");
 
-	is($ENV{BAZ}, "\x{62}\x{c4}\x{81}\x{7a}", "ENV{BAZ} $ENV{BAZ} is not unicode characters instead of utf-9 octets");
-	is(length($ENV{BAZ}), 4, "string is seen as 5 char bytes when not seen as utf-8");
-	ok(!Encode::is_utf8($ENV{BAZ}), "String is not seen as Perl Internal UTF-8");
+    is($ENV{BAR}, "\x{62}\x{61}\x{72}", "ENV{BAR} $ENV{BAR} is not unicode characters instead of utf-8 octets");
+    is(length($ENV{BAR}), 3, "string is seen as 3 char bytes when not seen as utf-8");
+    ok(!Encode::is_utf8($ENV{BAR}), "String is not seen as Perl Internal UTF-8");
 
-	is($ENV{BOO}, "\x{e3}\x{83}\x{86}\x{e3}\x{82}\x{b9}\x{e3}\x{83}\x{88}", "ENV{BOO} $ENV{BOO} is not unicode characters instead of utf-8 octets");
-	is(length($ENV{BOO}), 9, "string is seen as 9 char bytes when not seen as utf-8");
-	ok(!Encode::is_utf8($ENV{BOO}), "String is not seen as Perl Internal UTF-8");
+    is($ENV{BAZ}, "\x{62}\x{c4}\x{81}\x{7a}", "ENV{BAZ} $ENV{BAZ} is not unicode characters instead of utf-9 octets");
+    is(length($ENV{BAZ}), 4, "string is seen as 5 char bytes when not seen as utf-8");
+    ok(!Encode::is_utf8($ENV{BAZ}), "String is not seen as Perl Internal UTF-8");
+
+    is($ENV{BOO}, "\x{e3}\x{83}\x{86}\x{e3}\x{82}\x{b9}\x{e3}\x{83}\x{88}", "ENV{BOO} $ENV{BOO} is not unicode characters instead of utf-8 octets");
+    is(length($ENV{BOO}), 9, "string is seen as 9 char bytes when not seen as utf-8");
+    ok(!Encode::is_utf8($ENV{BOO}), "String is not seen as Perl Internal UTF-8");
 
 }
 

--- a/t/ENV_no_utf8_all.t
+++ b/t/ENV_no_utf8_all.t
@@ -1,0 +1,42 @@
+#!perl
+# Test that utf8::all makes @ENV utf8
+use strict;
+use warnings;
+
+use Encode;
+
+use Test::More tests => 1;
+
+# føø
+local $ENV{FOO} = join '', map {chr $_} ( 0x66, 0xc3, 0xb8, 0xc3, 0xb8 );
+
+# bar
+local $ENV{BAR} = 'bar';
+
+# bāz
+local $ENV{BAZ} = join '', map {chr $_} ( 0x62, 0xc4, 0x81, 0x7a );
+
+# テスト
+local $ENV{BOO} = join '', map {chr $_} (0xe3, 0x83, 0x86, 0xe3, 0x82, 0xb9, 0xe3, 0x83, 0x88);
+
+subtest 'ENV is not converted to Perl UTF8' => sub {
+	
+	# føø bar bāz テスト but now as unicode characters
+	is($ENV{FOO}, "\x{66}\x{c3}\x{b8}\x{c3}\x{b8}", "ENV{FOO} $ENV{FOO} is not unicode characters instead of utf-8 octets");
+	is(length($ENV{FOO}), 5, "string is seen as 5 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{FOO}), "String is not seen as Perl Internal UTF-8");
+
+	is($ENV{BAR}, "\x{62}\x{61}\x{72}", "ENV{BAR} $ENV{BAR} is not unicode characters instead of utf-8 octets");
+	is(length($ENV{BAR}), 3, "string is seen as 3 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{BAR}), "String is not seen as Perl Internal UTF-8");
+
+	is($ENV{BAZ}, "\x{62}\x{c4}\x{81}\x{7a}", "ENV{BAZ} $ENV{BAZ} is not unicode characters instead of utf-9 octets");
+	is(length($ENV{BAZ}), 4, "string is seen as 5 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{BAZ}), "String is not seen as Perl Internal UTF-8");
+
+	is($ENV{BOO}, "\x{e3}\x{83}\x{86}\x{e3}\x{82}\x{b9}\x{e3}\x{83}\x{88}", "ENV{BOO} $ENV{BOO} is not unicode characters instead of utf-8 octets");
+	is(length($ENV{BOO}), 9, "string is seen as 9 char bytes when not seen as utf-8");
+	ok(!Encode::is_utf8($ENV{BOO}), "String is not seen as Perl Internal UTF-8");
+
+};
+


### PR DESCRIPTION
* Add Support for converting ENV to UTF8. Issue #36
* Add POD for ENV changes
* Restore %ENV after unimport
---
This is the first PR on behalf of Adestra for the CPAN PRC for January 2018

There will be a performance hit to using a tied %ENV, however In my experience %ENV is not accessed on such a scale that the performance will be an issue. perhaps I'm wrong.

It is possible to disable the tie with NO-GLOBAL or `no utf8::all`